### PR TITLE
Fix `decodeStream` behavior on incomplete data.

### DIFF
--- a/Decoder.ts
+++ b/Decoder.ts
@@ -97,6 +97,10 @@ export class Decoder<ContextType> {
   }
 
   private appendBuffer(buffer: ArrayLike<number>) {
+    // Create a fresh copy of `buffer` while caller might re-use and
+    // modify the content of the `buffer`.
+    // This cause data pollution issue like #2.
+    buffer = ensureUint8Array(buffer).slice();
     if (this.headByte === HEAD_BYTE_REQUIRED && !this.hasRemaining()) {
       this.setBuffer(buffer);
     } else {

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+
+import { decodeStream, encode } from "../mod.ts";
+
+Deno.test("Test decodeStream properly handle complete data", async () => {
+  const reader = new Deno.Buffer(encode("0123456789"));
+  const stream = Deno.iter(reader, { bufSize: 10 });
+  const result = await consumeAll(decodeStream(stream));
+  assertEquals(result, ["0123456789"]);
+});
+
+Deno.test("Test decodeStream properly handle incomplete data", async () => {
+  const reader = new Deno.Buffer(encode("0123456789"));
+  const stream = Deno.iter(reader, { bufSize: 8 });
+  const result = await consumeAll(decodeStream(stream));
+  assertEquals(result, ["0123456789"]);
+});
+
+async function consumeAll<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const result = [];
+  for await (const item of it) {
+    result.push(item);
+  }
+  return result;
+}


### PR DESCRIPTION
Same as https://github.com/Srinivasa314/msgpack-deno/pull/2. For temporary use, I merge the branch to my master as well.